### PR TITLE
Adjustments for Chrome ~52 and latest GreaseMonkey/Firefox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-FlairLinker.zip: manifest.json FlairLinker.user.js icon-16.png icon-48.png icon-128.png
+FlairLinker.zip: manifest.json FlairLinker.user.js background.js icon-16.png icon-48.png icon-128.png
 	zip -u -v -db $@ $^
 
 clean:

--- a/background.js
+++ b/background.js
@@ -1,0 +1,30 @@
+/** Chrome background page listeners  **/
+
+/*
+ * Possible parameters for request:
+ *  action: "xhttp" for a cross-origin HTTP request
+ *  method: Default "GET"
+ *  url   : required, but not validated
+ *  data  : data to send in a POST request
+ *
+ * The callback function is called upon completion of the request */
+chrome.runtime.onMessage.addListener(function(request, sender, callback) {
+    if (request.action == "xhttp") {
+        var xhttp = new XMLHttpRequest();
+        var method = request.method ? request.method.toUpperCase() : 'GET';
+        xhttp.onload = function(e) {
+            callback(this.responseText);
+        };
+        xhttp.onerror = function() {
+            console.log("XHR Error: " + request.url);
+            // callback to clean up the communication port.
+            callback();
+        };
+        xhttp.open(method, request.url+request.data, true);
+        if (method == 'POST') {
+            xhttp.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+        }
+        xhttp.send();
+        return true; // prevents the callback from being called too early on return
+    }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,9 @@
 		"js": [ "FlairLinker.user.js" ],
 		"matches": [ "*://*.reddit.com/*" ],
 		"run_at": "document_idle"
-	} ]
+	} ],
+   "background": {
+      "scripts": ["background.js"],
+      "persistent": false
+   },
 }


### PR DESCRIPTION
- Added @grant permissions that GreaseMonkey asks for
- Chrome security prevents querying http (which Steam forces for ?xml=1)
  from reddit https. So adjusted the API query to happen via the
  background page (in background.js) rather than the loaded page.
- Changed more of the links to https
- Added h1z1market links/support
- Adjusted CSGO links to match modern popular sites
